### PR TITLE
hot reload on tab screens now take u to home instead of leaderboard

### DIFF
--- a/app/(drawer)/_layout.tsx
+++ b/app/(drawer)/_layout.tsx
@@ -222,11 +222,18 @@ export default function DrawerLayout() {
       })}
     >
       <Drawer.Screen 
-  name="leaderboard" 
-  options={{ 
-    title: "Leaderboard",
-  }} 
-/>
+        name="(tabs)" 
+        options={{ 
+          title: 'Home',
+          headerShown: false, // Explicitly hide header for home screen
+        }}
+      />
+      <Drawer.Screen 
+        name="leaderboard" 
+        options={{ 
+          title: "Leaderboard",
+        }} 
+      />
       <Drawer.Screen 
         name="settings" 
         options={{ 
@@ -262,13 +269,6 @@ export default function DrawerLayout() {
         options={{ 
           title: 'Expert Guide',
         }} 
-      />
-      <Drawer.Screen 
-        name="(tabs)" 
-        options={{ 
-          title: 'Home',
-          headerShown: false, // Explicitly hide header for home screen
-        }}
       />
     </Drawer>
   );

--- a/constants/DBAPI.ts
+++ b/constants/DBAPI.ts
@@ -5,7 +5,8 @@
 
 // jono's IP laptop
 //export const API_URL = 'http://192.168.1.134:3001';
-export const API_URL = 'http://192.168.0.118:3001';
+// jono laptop nids house
+//export const API_URL = 'http://192.168.0.118:3001';
 
 // jono's IP PC
-//export const API_URL = 'http://192.168.1.104:3001';
+export const API_URL = 'http://192.168.1.104:3001';


### PR DESCRIPTION
Hot reload doesn't keep the screen you were on when working on and saving files related to Drawer and Tab navigation. It changes it to the first Drawer item, which was leaderboard. It is now Home screen. It was the best I could do